### PR TITLE
Add basic maze loader and hover car scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # hoverboard-clone
+
 Cloning the classic Windows 95 game Hover!
+
+This repository contains GDScript helpers for Godot 4:
+
+- `Scripts/MazeLoader.gd` – loads MAZ files and instantiates simple tile scenes.
+- `Scripts/HoverCar.gd` – rudimentary hover car controller.
+- `Scripts/Main.gd` – ties the maze loader and hover car together; expects
+  children named `MazeLoader` and `HoverCar` in the scene.
+
+Drop `Assets/Mazes/*.MAZ` and simple `Assets/Scenes` scene files into a Godot
+project to run.

--- a/Scripts/HoverCar.gd
+++ b/Scripts/HoverCar.gd
@@ -1,0 +1,29 @@
+extends RigidBody3D
+
+@export var thrust: float = 20.0
+@export var turn_speed: float = 3.0
+@export var hover_height: float = 1.5
+@export var hover_force: float = 30.0
+@export var damping: float = 4.0
+@export var max_speed: float = 25.0
+
+func _physics_process(delta: float) -> void:
+    var forward := Input.get_action_strength("move_forward") - Input.get_action_strength("move_back")
+    if forward != 0.0:
+        apply_central_force(-transform.basis.z * thrust * forward)
+
+    var turn := Input.get_action_strength("turn_right") - Input.get_action_strength("turn_left")
+    if turn != 0.0:
+        apply_torque_impulse(Vector3.UP * turn * turn_speed)
+
+    var from := global_transform.origin
+    var to := from + Vector3.DOWN * (hover_height + 2.0)
+    var res := get_world_3d().direct_space_state.intersect_ray(from, to, [self])
+    if res:
+        var dist := from.y - res.position.y
+        var force := (hover_height - dist) * hover_force
+        if force > 0.0:
+            apply_central_force(Vector3.UP * force)
+
+    var lv := linear_velocity.move_toward(Vector3.ZERO, damping * delta)
+    linear_velocity = lv.limit_length(max_speed)

--- a/Scripts/Main.gd
+++ b/Scripts/Main.gd
@@ -1,0 +1,8 @@
+extends Node3D
+
+@onready var maze_loader: Node3D = $MazeLoader
+@onready var hover_car: RigidBody3D = $HoverCar
+
+func _ready() -> void:
+    var spawn := maze_loader.load_maze("MAZE1.MAZ")
+    hover_car.global_position = spawn

--- a/Scripts/MazeLoader.gd
+++ b/Scripts/MazeLoader.gd
@@ -1,0 +1,36 @@
+extends Node3D
+
+const MAZE_WIDTH: int = 48
+const MAZE_HEIGHT: int = 32
+const TILE_SIZE: float = 2.0
+
+var tile_scenes := {
+    0: preload("res://Assets/Scenes/Floor.tscn"),
+    1: preload("res://Assets/Scenes/Wall.tscn"),
+    2: preload("res://Assets/Scenes/PlayerSpawn.tscn"),
+}
+
+func load_maze(filename: String) -> Vector3:
+    var file := FileAccess.open("res://Assets/Mazes/%s" % filename, FileAccess.READ)
+    if file == null:
+        push_error("Couldn't open %s" % filename)
+        return Vector3.ZERO
+    var data := file.get_buffer(file.get_length())
+    file.close()
+
+    if data.size() != MAZE_WIDTH * MAZE_HEIGHT:
+        push_error("Unexpected file size: %s" % data.size())
+        return Vector3.ZERO
+
+    var spawn_position := Vector3.ZERO
+
+    for y in range(MAZE_HEIGHT):
+        for x in range(MAZE_WIDTH):
+            var idx := data[y * MAZE_WIDTH + x]
+            if tile_scenes.has(idx):
+                var tile := tile_scenes[idx].instantiate()
+                tile.position = Vector3(x * TILE_SIZE, 0, y * TILE_SIZE)
+                add_child(tile)
+                if idx == 2:
+                    spawn_position = tile.position + Vector3.UP
+    return spawn_position


### PR DESCRIPTION
## Summary
- load simple MAZ files into a 3D grid of floor, wall, and spawn tiles
- add a rudimentary hover car controller with thrust, turning, and hovering forces
- provide a main script connecting the maze and hover car

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689569fc1b4c832098ac44db7f5cc74e